### PR TITLE
Add tasks on bound

### DIFF
--- a/lib/pon.js
+++ b/lib/pon.js
@@ -70,7 +70,12 @@ class Pon extends PonBase {
   bind () {
     const s = this
     const run = s.run.bind(s)
-    return Object.assign(run, {})
+    return Object.assign(run, {
+      $$pon: true,
+      bind: () => s.bind(),
+      run,
+      tasks: s.tasks
+    })
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pon",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Simple task runner to make you happy.",
   "main": "lib",
   "browser": "ci/browser",


### PR DESCRIPTION
`require('pon')({ /* ... */ })`とやると、Pon#runをbindした関数が返ってくる仕様なのだけど、CLIで使うときのはそこからさらに元のtaskを参照したい。ので対応した