### PR TITLE
Taskをalias実行できるようにした

### DIFF
--- a/lib/mixins/task_mix.js
+++ b/lib/mixins/task_mix.js
@@ -22,6 +22,11 @@ function taskMix (BaseClass) {
       s.tasks = {}
     }
 
+    getTask (name) {
+      const s = this
+      return s.tasks[ name ]
+    }
+
     registerTasks (tasks) {
       const s = this
       for (let name of Object.keys(tasks)) {
@@ -45,7 +50,6 @@ function taskMix (BaseClass) {
       const s = this
       const { tasks } = s
       return Object.keys(tasks)
-        .filter((name) => typeof tasks[ name ] === 'function')
         .filter((name) => patterns.some((pattern) => minimatch(name, pattern)))
         .reduce((resolved, name) => Object.assign(resolved, {
           [name]: tasks[ name ]

--- a/lib/pon.js
+++ b/lib/pon.js
@@ -51,12 +51,25 @@ class Pon extends PonBase {
         })
         let { timer, logger } = ctx
         for (let taskName of taskNames) {
-          let task = tasks[ taskName ]
-          timer.tick(TICK_TASK)
-          logger.info(`Task "${taskName}" started...`)
-          results[ taskName ] = yield Promise.resolve(task(ctx))
-          let took = timer.tick(TICK_TASK)
-          logger.info(`... task "${taskName}" done! (${took}ms)\n`)
+          for (let task of [].concat(tasks[ taskName ])) {
+            let isAlias = typeof task === 'string'
+            if (isAlias) {
+              let taskAliasName = String(task)
+              task = s.getTask(taskAliasName)
+              if (!task) {
+                throw new Error(`Unknown task: ${taskAliasName}`)
+              }
+            }
+            if (typeof task === 'object') {
+              task = task.default
+            }
+            timer.tick(TICK_TASK)
+            logger.info(`Task "${taskName}" started...`)
+            let result = yield Promise.resolve(task(ctx))
+            results[ taskName ] = [ ...(results[ taskName ] || []), result ]
+            let took = timer.tick(TICK_TASK)
+            logger.info(`... task "${taskName}" done! (${took}ms)\n`)
+          }
         }
       }
       return results

--- a/test/pon_test.js
+++ b/test/pon_test.js
@@ -28,7 +28,7 @@ describe('pon', function () {
       })
     }).bind()
     let results = yield run('foo')
-    deepEqual(results, { foo: 'foo finished!' })
+    deepEqual(results, { foo: ['foo finished!'] })
   }))
 
   it('pattern', () => co(function * () {
@@ -39,7 +39,7 @@ describe('pon', function () {
       })
     }).bind()
     let results = yield run('fo*')
-    deepEqual(results, { foo: 'foo finished!' })
+    deepEqual(results, { foo: ['foo finished!'] })
   }))
 
   it('Nested', () => co(function * () {
@@ -49,7 +49,18 @@ describe('pon', function () {
       }
     }).bind()
     let results = yield run('foo.bar')
-    deepEqual(results, { 'foo.bar': 'This is baz!' })
+    deepEqual(results, { 'foo.bar': ['This is baz!'] })
+  }))
+
+  it('Alias', () => co(function * () {
+    let run = new Pon({
+      foo: {
+        bar: () => 'This is baz!'
+      },
+      baz: [ 'foo.bar' ]
+    }).bind()
+    let results = yield run('baz')
+    deepEqual(results, { 'baz': ['This is baz!'] })
   }))
 })
 


### PR DESCRIPTION
Taskとして別のタスク名を文字列で渡すとaliasとなり、間接的に実行できるようにした


```javascript

it('Alias', () => co(function * () {
    let run = new Pon({
      foo: {
        bar: () => 'This is baz!'
      },
      baz: [ 'foo.bar' ]
    }).bind()
    let results = yield run('baz')
    deepEqual(results, { 'baz': ['This is baz!'] })
  }))

```