### PR TITLE
パターンで渡されたタスクはparallel実行されるようにした

### DIFF
--- a/lib/pon.js
+++ b/lib/pon.js
@@ -45,32 +45,35 @@ class Pon extends PonBase {
       let results = {}
       for (let pattern of patterns) {
         let tasks = s.resolveTasks(...pattern.split(','))
-        let taskNames = Object.keys(tasks)
-        let ctx = s.newContext({
-          tasks: taskNames
-        })
-        let { timer, logger } = ctx
-        for (let taskName of taskNames) {
-          for (let task of [].concat(tasks[ taskName ])) {
-            let isAlias = typeof task === 'string'
-            if (isAlias) {
-              let taskAliasName = String(task)
-              task = s.getTask(taskAliasName)
-              if (!task) {
-                throw new Error(`Unknown task: ${taskAliasName}`)
+        // Run parallel
+        yield Promise.all(
+          Object.keys(tasks).map((taskName) => co(function * () {
+            let ctx = s.newContext({
+              task: taskName
+            })
+            let { timer, logger } = ctx
+            logger.PREFIX = `[${taskName}] `
+            for (let task of [].concat(tasks[ taskName ])) {
+              let isAlias = typeof task === 'string'
+              if (isAlias) {
+                let taskAliasName = String(task)
+                task = s.getTask(taskAliasName)
+                if (!task) {
+                  throw new Error(`Unknown task: ${taskAliasName}`)
+                }
               }
+              if (typeof task === 'object') {
+                task = task.default
+              }
+              timer.tick(TICK_TASK)
+              logger.info(`Task started...`)
+              let result = yield Promise.resolve(task(ctx))
+              results[ taskName ] = [ ...(results[ taskName ] || []), result ]
+              let took = timer.tick(TICK_TASK)
+              logger.info(`...done! (${took}ms)\n`)
             }
-            if (typeof task === 'object') {
-              task = task.default
-            }
-            timer.tick(TICK_TASK)
-            logger.info(`Task "${taskName}" started...`)
-            let result = yield Promise.resolve(task(ctx))
-            results[ taskName ] = [ ...(results[ taskName ] || []), result ]
-            let took = timer.tick(TICK_TASK)
-            logger.info(`... task "${taskName}" done! (${took}ms)\n`)
-          }
-        }
+          }))
+        )
       }
       return results
     })

--- a/test/pon_test.js
+++ b/test/pon_test.js
@@ -28,18 +28,27 @@ describe('pon', function () {
       })
     }).bind()
     let results = yield run('foo')
-    deepEqual(results, { foo: ['foo finished!'] })
+    deepEqual(results, { foo: [ 'foo finished!' ] })
   }))
 
   it('pattern', () => co(function * () {
     let run = new Pon({
-      foo: () => co(function * () {
+      foo: (ctx) => co(function * () {
         yield asleep(100)
+        ctx.logger.debug('Log of foo')
         return 'foo finished!'
+      }),
+      bar: (ctx) => co(function * () {
+        yield asleep(100)
+        ctx.logger.debug('Log of bar')
+        return 'bar finished!'
       })
     }).bind()
-    let results = yield run('fo*')
-    deepEqual(results, { foo: ['foo finished!'] })
+    let results = yield run('*')
+    deepEqual(results, {
+      foo: [ 'foo finished!' ],
+      bar: [ 'bar finished!' ]
+    })
   }))
 
   it('Nested', () => co(function * () {
@@ -49,7 +58,7 @@ describe('pon', function () {
       }
     }).bind()
     let results = yield run('foo.bar')
-    deepEqual(results, { 'foo.bar': ['This is baz!'] })
+    deepEqual(results, { 'foo.bar': [ 'This is baz!' ] })
   }))
 
   it('Alias', () => co(function * () {
@@ -60,7 +69,7 @@ describe('pon', function () {
       baz: [ 'foo.bar' ]
     }).bind()
     let results = yield run('baz')
-    deepEqual(results, { 'baz': ['This is baz!'] })
+    deepEqual(results, { 'baz': [ 'This is baz!' ] })
   }))
 })
 


### PR DESCRIPTION
スピードアップのため。

```javascript
const run = pon({
   'foo:1': () => { /* ... */ },
   'foo:2': () => { /* ... */ },
   'bar': () => { /* ... */ }
})

run('foo:*', 'bar')
```

と実行すると、"foo:1"と"foo:2"がパラレルに実行され、それが終わったらbarに移る仕様にした

